### PR TITLE
Improve startup diagnostics for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ python main.py --gui
   ```
 
 * Danach kannst du die App einfach per Doppelklick auf `main.py` oder `start-memoryball.bat` starten.
-  * `start-memoryball.bat` lässt das Terminal bei Fehlern offen und zeigt den gleichen Hinweis wie die GUI an.
-  * Bei fehlenden Bibliotheken erscheint eine verständliche Fehlermeldung mit Lösungsvorschlägen (z. B. für Tkinter oder Pillow).
-* Im Fehlerfall findest du zusätzliche Details in `startup-errors.log` im Projektordner.
+  * `start-memoryball.bat` lässt das Terminal bei Fehlern offen, schreibt alle Fehlermeldungen in `startup-errors.log` und blendet das Protokoll sofort ein.
+  * Bei fehlenden Bibliotheken erscheint eine verständliche Fehlermeldung mit Lösungsvorschlägen (z. B. für Tkinter, Pillow oder OpenCV).
+* Auch beim Doppelklick auf `main.py` wird der Fehler im gleichen Log abgelegt, sodass du ihn jederzeit nachlesen kannst.
 
 ## Performance-Tipps
 
@@ -122,6 +122,7 @@ python main.py --gui
 * **HEIC wird nicht gelesen** – Stelle sicher, dass `pillow-heif` installiert ist und die Datei nicht DRM-geschützt ist.
 * **Beschädigte Metadaten** – ffmpeg/ffprobe können bei fehlerhaften Dateien abbrechen. Die Anwendung loggt Warnungen und verarbeitet den Rest weiter.
 * **Gesicht wird nicht erkannt** – Erhöhe `--min-face` nicht zu stark, nutze `--face-priority center` oder deaktiviere die Erkennung (`--no-face`).
+* **`ModuleNotFoundError: No module named 'cv2'`** – OpenCV ist nicht installiert. Führe `python -m pip install -r requirements.txt` in deinem Projektordner aus.
 
 ## Tests
 

--- a/src/face_cropper.py
+++ b/src/face_cropper.py
@@ -5,7 +5,12 @@ import contextlib
 from dataclasses import dataclass
 from typing import Iterable, List, Optional, Tuple
 
-import cv2
+try:
+    import cv2
+except ModuleNotFoundError as exc:  # pragma: no cover - better error hint for Windows users
+    raise RuntimeError(
+        "OpenCV (cv2) ist nicht installiert. Bitte `pip install -r requirements.txt` ausführen."
+    ) from exc
 import numpy as np
 
 try:  # pragma: no cover - optional dependency check

--- a/start-memoryball.bat
+++ b/start-memoryball.bat
@@ -10,14 +10,24 @@ if exist "%~dp0venv\Scripts\python.exe" (
     set "PYTHON=python"
 )
 
-"%PYTHON%" "%~dp0main.py" %*
+
+set "LOGFILE=%~dp0startup-errors.log"
+if exist "%LOGFILE%" del "%LOGFILE%"
+
+"%PYTHON%" "%~dp0main.py" %* 2> "%LOGFILE%"
 set EXITCODE=%ERRORLEVEL%
 
 if %EXITCODE% neq 0 (
     echo.
+    echo ===== Fehlerprotokoll =====
+    if exist "%LOGFILE%" type "%LOGFILE%"
+    echo ===========================
+    echo.
     echo Der Start ist fehlgeschlagen. Details stehen in startup-errors.log.
     echo Bitte pruefe die angezeigte Fehlermeldung.
     pause
+) else (
+    if exist "%LOGFILE%" del "%LOGFILE%"
 )
 
 endlocal


### PR DESCRIPTION
## Summary
- write Python stderr to a persistent `startup-errors.log` in the Windows start script and display the log automatically on failure
- improve the OpenCV import error message to explain how to install the missing dependency
- update the README with clearer Windows troubleshooting notes and guidance for the new log file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e3e1028ff0832098b8232f76232b53