### PR TITLE
Fix Segoe UI font option initialization

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -77,8 +77,8 @@ class Application(tk.Tk):
         card_background = "#161a27"
         accent = "#3f8efc"
         self.configure(background=background)
-        self.option_add("*Font", "Segoe UI 10")
-        self.option_add("*Label.font", "Segoe UI 10")
+        self.option_add("*Font", "{Segoe UI} 10")
+        self.option_add("*Label.font", "{Segoe UI} 10")
         self.option_add("*Entry.background", card_background)
         self.option_add("*Entry.foreground", "#f5f7fa")
         self.option_add("*Entry.insertBackground", "#f5f7fa")


### PR DESCRIPTION
## Summary
- wrap the Segoe UI font name in braces when configuring Tk defaults to keep Tk from parsing the family name as multiple tokens

## Testing
- not run (GUI change)


------
https://chatgpt.com/codex/tasks/task_e_68e3ee6b08e88320b479e9c90e1c2973