### PR TITLE
Align orientation circle with top of crop rectangle

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -1098,11 +1098,16 @@ class Application(tk.Tk):
         if diameter <= 0:
             return
         margin = diameter * self.CIRCLE_MARGIN
+        top = y1
+        bottom = y2 - 2 * margin
+        if bottom <= top:
+            top = y1 + margin
+            bottom = y2 - margin
         self.canvas.create_oval(
             x1 + margin,
-            y1 + margin,
+            top,
             x2 - margin,
-            y2 - margin,
+            bottom,
             outline=color,
             width=line_width,
         )


### PR DESCRIPTION
## Summary
- shift the orientation circle drawing so it touches the top edge of the crop rectangle while keeping its size consistent
- add a safeguard to retain the previous positioning when the adjusted height would collapse

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5247a27548320931f5e42c16f0ae4