### PR TITLE
Align crops with orientation circle

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -20,6 +20,7 @@ from .utils import (
     CropBox,
     ManualCrop,
     ProcessingOptions,
+    ORIENTATION_CIRCLE_MARGIN,
     clamp,
     crop_position_bounds,
     ensure_dir,
@@ -29,6 +30,7 @@ from .utils import (
     max_crop_size,
     normalize_crop_with_overflow,
     setup_environment,
+    square_size_for_circle,
 )
 from .video_pipeline import process_video
 
@@ -37,7 +39,7 @@ class Application(tk.Tk):
     """Tkinter-Anwendung mit Vorschau und manueller Zuschnittssteuerung."""
 
     CANVAS_SIZE = 520
-    CIRCLE_MARGIN = 0.1
+    CIRCLE_MARGIN = ORIENTATION_CIRCLE_MARGIN
     DETECTION_CHOICES = [
         ("face", "Gesichtserkennung"),
         ("person", "Menscherkennung"),
@@ -905,7 +907,7 @@ class Application(tk.Tk):
         width, height = self.current_image.size
         end = self._normalize_crop_box(CropBox(crop.x, crop.y, crop.size), width, height)
         if self.motion_enabled_var.get():
-            start_size = end.size
+            start_size = square_size_for_circle(float(min(width, height)))
             start_x = (width - start_size) / 2
             start_y = (height - start_size) / 2
             start = self._normalize_crop_box(CropBox(start_x, start_y, start_size), width, height)

--- a/src/utils.py
+++ b/src/utils.py
@@ -35,6 +35,37 @@ class CropBox:
 
 
 CROP_OVERFLOW_RATIO = 0.5
+ORIENTATION_CIRCLE_MARGIN = 0.1
+
+
+def _circle_fraction(circle_margin: float) -> float:
+    """Return the fraction of a square that remains after applying the circle margin."""
+
+    if circle_margin <= 0.0:
+        return 1.0
+    return max(0.0, 1.0 - 2.0 * circle_margin)
+
+
+def square_size_for_circle(diameter: float, circle_margin: float = ORIENTATION_CIRCLE_MARGIN) -> float:
+    """Return the side length of a square whose inscribed circle matches ``diameter``."""
+
+    diameter = max(0.0, float(diameter))
+    fraction = _circle_fraction(circle_margin)
+    if fraction <= 0.0:
+        return diameter
+    return diameter / fraction if diameter else 0.0
+
+
+def expand_crop_for_circle(crop: CropBox, circle_margin: float = ORIENTATION_CIRCLE_MARGIN) -> CropBox:
+    """Expand ``crop`` so that the orientation circle matches the detected region."""
+
+    fraction = _circle_fraction(circle_margin)
+    if fraction <= 0.0:
+        return CropBox(crop.x, crop.y, crop.size)
+    new_size = crop.size / fraction
+    center_x = crop.x + crop.size / 2.0
+    center_y = crop.y + crop.size / 2.0
+    return CropBox(x=center_x - new_size / 2.0, y=center_y - new_size / 2.0, size=new_size)
 
 
 def crop_position_bounds(size: float, dimension: int, overflow_ratio: float = CROP_OVERFLOW_RATIO) -> Tuple[float, float]:

--- a/src/video_pipeline.py
+++ b/src/video_pipeline.py
@@ -16,6 +16,7 @@ from .utils import (
     normalize_crop_with_overflow,
     run_ffprobe,
     safe_output_path,
+    square_size_for_circle,
 )
 
 
@@ -27,10 +28,10 @@ class VideoResult:
 
 
 def _center_crop(width: int, height: int, pad: float = 0.0) -> CropBox:
-    size = min(width, height)
+    diameter = float(min(width, height))
     if pad:
-        size = int(size * (1 - pad))
-        size = max(1, size)
+        diameter = max(1.0, diameter * (1 - pad))
+    size = square_size_for_circle(diameter)
     x = (width - size) / 2
     y = (height - size) / 2
     return CropBox(x=x, y=y, size=size)


### PR DESCRIPTION
## Summary
- expand detection boxes to align the crop window with the orientation circle and reuse selection logic for tracking
- share circle sizing helpers across the pipelines and GUI so the initial and fallback crops center the circle correctly
- update the video pipeline fallback crop to match the new circle sizing behaviour

## Testing
- pytest -q memoryball-studio/tests

------
https://chatgpt.com/codex/tasks/task_e_68e5293ba2688320a850016ed2ca1e9f