### PR TITLE
Improve orientation circle centering and multi-face focus

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -909,7 +909,8 @@ class Application(tk.Tk):
         if self.motion_enabled_var.get():
             start_size = square_size_for_circle(float(min(width, height)))
             start_x = (width - start_size) / 2
-            start_y = (height - start_size) / 2
+            vertical_margin = start_size * self.CIRCLE_MARGIN
+            start_y = (height - start_size) / 2 + vertical_margin
             start = self._normalize_crop_box(CropBox(start_x, start_y, start_size), width, height)
         else:
             start = CropBox(end.x, end.y, end.size)

--- a/src/image_pipeline.py
+++ b/src/image_pipeline.py
@@ -69,16 +69,20 @@ def determine_crop_box(
         detections = face_cropper.detect_subjects(array_bgr)
         crop_box = base_crop
         if detections:
-            target = face_cropper.select_detection(detections, width, height)
-            if target is not None:
-                size = target.box.size
-                center_x = target.box.x + size / 2
-                center_y = target.box.y + size / 2
-                crop_box = CropBox(x=center_x - size / 2, y=center_y - size / 2, size=size)
+            combined = face_cropper.combine_detections(detections, width, height)
+            if combined is not None:
+                crop_box = combined
             else:
-                focus = face_cropper.focus_window(detections, width, height, base_crop.size)
-                if focus is not None:
-                    crop_box = focus
+                target = face_cropper.select_detection(detections, width, height)
+                if target is not None:
+                    size = target.box.size
+                    center_x = target.box.x + size / 2
+                    center_y = target.box.y + size / 2
+                    crop_box = CropBox(x=center_x - size / 2, y=center_y - size / 2, size=size)
+                else:
+                    focus = face_cropper.focus_window(detections, width, height, base_crop.size)
+                    if focus is not None:
+                        crop_box = focus
     else:
         crop_box = base_crop
     return _normalize_crop(width, height, crop_box)


### PR DESCRIPTION
## Summary
- center the initial orientation circle by offsetting the start crop with the circle margin before normalization
- add heuristics that combine multiple confident detections into one crop, weighted to cover several faces
- reuse the combined detection crop for images and video tracking so the second circle stays on the key subjects

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e52da7b674832091d6eefd7f6c2ed9