### PR TITLE
Improve automatic motion planning for face crops

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,6 +56,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--format", help="Optionales Format-Preset, z.B. jpg,mp4")
     parser.add_argument("--no-face", action="store_true", help="Gesichtserkennung deaktivieren")
     parser.add_argument("--gui", action="store_true", help="Tkinter-GUI starten")
+    parser.add_argument(
+        "--motion-direction",
+        choices=["in", "out"],
+        default="in",
+        help="Standardrichtung für automatische Bewegungen (rein- oder rauszoomen)",
+    )
     return parser.parse_args()
 
 
@@ -98,6 +104,7 @@ def build_options(args: argparse.Namespace) -> ProcessingOptions:
         log_level=args.log_level,
         face_detection_enabled=detection_mode != "none",
         detection_mode=detection_mode,
+        motion_direction=args.motion_direction,
     )
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -140,6 +140,7 @@ class ProcessingOptions:
     face_detection_enabled: bool = True
     detection_mode: str = "face"
     motion_enabled: bool = True
+    motion_direction: str = "in"
 
 
 class ProgressLogger:


### PR DESCRIPTION
## Summary
- add a motion planning helper in `FaceCropper` to keep all faces within the green circle and bias the body view for the red circle
- expose the behaviour through a new `determine_motion_manual` helper and a motion-direction option available via CLI and GUI
- refresh the GUI to offer an in/out zoom selector and reuse the new motion planner for automatic previews

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e54e2cb6848320af99cc99e6b16a5a